### PR TITLE
Remove redundant types in frontmatter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ Hugo and AsciiDoctor locally or run a Docker image that contains Hugo and AsciiD
 
 ==== Install Hugo and AsciiDoctor locally
 
-If you want to locally install the required tools, you must first install link://https://gohugo.io/[Hugo]
+If you want to locally install the required tools, you must first install link:https://gohugo.io/[Hugo]
 and have the `hugo` command available on your PATH. You should use at least **Hugo 0.48**. You can easily
 install `hugo` by using your system's package manager. Try the following command, which takes a while to
 complete:

--- a/content/how-to/contribution-class/contribution-class-exercise/index.md
+++ b/content/how-to/contribution-class/contribution-class-exercise/index.md
@@ -2,7 +2,6 @@
 title: Contribution class exercise
 type: practice
 created_date: '2016-05-25'
-type: article
 created_by: Nate Archer
 last_modified_date: '2019-05-16'
 last_modified_by: Hiten Mistry

--- a/content/how-to/dedicated-hosting/dedicated-hosting-faq/index.md
+++ b/content/how-to/dedicated-hosting/dedicated-hosting-faq/index.md
@@ -2,7 +2,6 @@
 permalink: dedicated-hosting-faq/
 audit_date: '2016-11-09'
 title: Dedicated Hosting FAQ
-type: article
 type: product
 created_date: '2016-11-01'
 created_by: Stephanie Fillmon

--- a/content/how-to/dedicated-hosting/dedicated-hosting-faq/index.md
+++ b/content/how-to/dedicated-hosting/dedicated-hosting-faq/index.md
@@ -2,7 +2,7 @@
 permalink: dedicated-hosting-faq/
 audit_date: '2016-11-09'
 title: Dedicated Hosting FAQ
-type: faq
+type: article
 created_date: '2016-11-01'
 created_by: Stephanie Fillmon
 last_modified_date: '2018-11-28'

--- a/content/how-to/dedicated-hosting/dedicated-hosting-faq/index.md
+++ b/content/how-to/dedicated-hosting/dedicated-hosting-faq/index.md
@@ -2,7 +2,7 @@
 permalink: dedicated-hosting-faq/
 audit_date: '2016-11-09'
 title: Dedicated Hosting FAQ
-type: product
+type: faq
 created_date: '2016-11-01'
 created_by: Stephanie Fillmon
 last_modified_date: '2018-11-28'

--- a/content/how-to/general/legal/index.md
+++ b/content/how-to/general/legal/index.md
@@ -2,7 +2,7 @@
 permalink: legal/
 audit_date:
 title: RACKSPACE HOW-TO LICENSE
-type: page
+type: article
 created_date: '2012-08-24'
 created_by: Rackspace Support
 last_modified_date: '2018-11-27'

--- a/content/how-to/general/legal/index.md
+++ b/content/how-to/general/legal/index.md
@@ -2,7 +2,6 @@
 permalink: legal/
 audit_date:
 title: RACKSPACE HOW-TO LICENSE
-type: article
 type: page
 created_date: '2012-08-24'
 created_by: Rackspace Support

--- a/content/how-to/general/support/index.md
+++ b/content/how-to/general/support/index.md
@@ -2,7 +2,7 @@
 permalink: support/
 audit_date: '2018-12-13'
 title: How to contact Rackspace Support
-type: page
+type: article
 created_date: '2013-06-17'
 created_by: Rackspace Support
 last_modified_date: '2018-12-13'

--- a/content/how-to/general/support/index.md
+++ b/content/how-to/general/support/index.md
@@ -2,7 +2,6 @@
 permalink: support/
 audit_date: '2018-12-13'
 title: How to contact Rackspace Support
-type: article
 type: page
 created_date: '2013-06-17'
 created_by: Rackspace Support

--- a/content/how-to/general/understanding-the-cloud-computing-stack-Saas-Paas-Iaas/index.md
+++ b/content/how-to/general/understanding-the-cloud-computing-stack-Saas-Paas-Iaas/index.md
@@ -2,7 +2,7 @@
 permalink: understanding-the-cloud-computing-stack-saas-paas-iaas/
 audit_date: '2020-03-31'
 title: 'Understanding the cloud computing stack: SaaS, PaaS, and IaaS'
-type: page
+type: article
 created_date: '2012-07-23'
 created_by: Rackspace Support
 last_modified_date: '2020-04-01'

--- a/content/how-to/general/understanding-the-cloud-computing-stack-Saas-Paas-Iaas/index.md
+++ b/content/how-to/general/understanding-the-cloud-computing-stack-Saas-Paas-Iaas/index.md
@@ -2,7 +2,6 @@
 permalink: understanding-the-cloud-computing-stack-saas-paas-iaas/
 audit_date: '2020-03-31'
 title: 'Understanding the cloud computing stack: SaaS, PaaS, and IaaS'
-type: article
 type: page
 created_date: '2012-07-23'
 created_by: Rackspace Support

--- a/content/how-to/rackspace-email-archiving/rackspace-email-archiving-faq/index.md
+++ b/content/how-to/rackspace-email-archiving/rackspace-email-archiving-faq/index.md
@@ -1,7 +1,7 @@
 ---
 permalink: rackspace-email-archiving-faq/
 title: Rackspace Email Archiving FAQ
-type: product
+type: faq
 created_date: '2016-01-17'
 created_by: Rackspace Support
 last_modified_date: '2016-01-26'

--- a/content/how-to/rackspace-email-archiving/rackspace-email-archiving-faq/index.md
+++ b/content/how-to/rackspace-email-archiving/rackspace-email-archiving-faq/index.md
@@ -1,7 +1,7 @@
 ---
 permalink: rackspace-email-archiving-faq/
 title: Rackspace Email Archiving FAQ
-type: faq
+type: article
 created_date: '2016-01-17'
 created_by: Rackspace Support
 last_modified_date: '2016-01-26'

--- a/content/how-to/rackspace-email-archiving/rackspace-email-archiving-faq/index.md
+++ b/content/how-to/rackspace-email-archiving/rackspace-email-archiving-faq/index.md
@@ -2,7 +2,6 @@
 permalink: rackspace-email-archiving-faq/
 title: Rackspace Email Archiving FAQ
 type: product
-type: article
 created_date: '2016-01-17'
 created_by: Rackspace Support
 last_modified_date: '2016-01-26'

--- a/content/how-to/rackspace-email/best-practices-for-sending-emails-to-many-recipients/index.md
+++ b/content/how-to/rackspace-email/best-practices-for-sending-emails-to-many-recipients/index.md
@@ -3,7 +3,6 @@ permalink: best-practices-for-sending-emails-to-many-recipients/
 audit_date: '2017-05-30'
 title: Best practices for sending emails to many recipients
 type: article
-type: article
 created_date: '2015-12-22'
 created_by: Beau Bailey
 last_modified_date: '2017-05-30'

--- a/content/how-to/rackspace-email/best-practices-for-sending-person-to-person-email/index.md
+++ b/content/how-to/rackspace-email/best-practices-for-sending-person-to-person-email/index.md
@@ -3,7 +3,6 @@ permalink: best-practices-for-sending-person-to-person-email/
 audit_date: '2017-05-30'
 title: Best practices for sending person-to-person email
 type: article
-type: article
 created_date: '2017-05-17'
 created_by: Beau Bailey
 last_modified_date: '2017-10-19'

--- a/content/how-to/rackspace-email/cloud-office-blocked-attachment-files/index.md
+++ b/content/how-to/rackspace-email/cloud-office-blocked-attachment-files/index.md
@@ -3,7 +3,6 @@ permalink: cloud-office-blocked-attachment-files/
 audit_date: '2017-05-30'
 title: Cloud Office Blocked Attachment Types
 type: article
-type: article
 created_date: '2017-05-19'
 created_by: William Loy
 last_modified_date: '2017-06-02'

--- a/content/how-to/rackspace-email/common-email-bounces/index.md
+++ b/content/how-to/rackspace-email/common-email-bounces/index.md
@@ -3,7 +3,6 @@ permalink: common-email-bounces/
 audit_date: '2018-02-07'
 title: Common email bounce messages
 type: article
-type: article
 created_date: '2017-05-18'
 created_by: William Loy
 last_modified_date: '2018-02-07'

--- a/content/how-to/rackspace-email/dns-record-definitions/index.md
+++ b/content/how-to/rackspace-email/dns-record-definitions/index.md
@@ -3,7 +3,6 @@ permalink: dns-record-definitions/
 audit_date: '2017-05-30'
 title: DNS record definitions
 type: article
-type: article
 created_date: '2017-05-17'
 created_by: William Loy
 last_modified_date: '2017-05-30'

--- a/content/how-to/rackspace-email/find-dns-host/index.md
+++ b/content/how-to/rackspace-email/find-dns-host/index.md
@@ -3,7 +3,6 @@ permalink: find-dns-host/
 audit_date: '2017-05-30'
 title: Find your DNS host
 type: article
-type: article
 created_date: '2017-05-17'
 created_by: William Loy
 last_modified_date: '2017-05-30'

--- a/content/how-to/rackspace-email/set-up-dns-records-for-cloud-office-email/index.md
+++ b/content/how-to/rackspace-email/set-up-dns-records-for-cloud-office-email/index.md
@@ -3,7 +3,6 @@ permalink: set-up-dns-records-for-cloud-office-email/
 audit_date: '2017-05-30'
 title: Set up DNS records for Cloud Office email
 type: article
-type: article
 created_date: '2014-08-15'
 created_by: William Loy
 last_modified_date: '2017-10-20'

--- a/content/how-to/rackspace-pdr/rackspace-pdr-faq/index.md
+++ b/content/how-to/rackspace-pdr/rackspace-pdr-faq/index.md
@@ -2,7 +2,6 @@
 permalink: rackspace-pdr-faq/
 title: Rackspace PDR FAQ
 type: faq
-type: article
 audit_date: '2018-11-12'
 created_date: '2018-10-11'
 created_by: Nick Shobe

--- a/content/how-to/skype-for-business/download-a-skype-for-business-client/index.md
+++ b/content/how-to/skype-for-business/download-a-skype-for-business-client/index.md
@@ -3,7 +3,6 @@ permalink: download-a-skype-for-business-client/
 audit_date: '2017-05-25'
 title: Download a Skype for Business client
 type: article
-type: article
 created_date: '2014-04-16'
 created_by: Kevin Richey
 last_modified_date: '2017-05-23'


### PR DESCRIPTION
We're doing a project that sources some of these articles and parses them. During this process we found some issues that may be worth fixing. I removed all the redundant `article` types, but there's also a few posts here that had a non-article type specified in the frontmatter so we can make a case-by-case choice for those if you wish.