### PR TITLE
remove superfluous p tags

### DIFF
--- a/content/how-to/account-management/account-management-faq/index.md
+++ b/content/how-to/account-management/account-management-faq/index.md
@@ -283,6 +283,7 @@ Following is the initial pop-up window that appears when you enable RBAC.
 
 {{<image src="RBAC.png" alt="" title="">}}
 
+<br />
 
 For information about additional products that will be RBAC-enabled in
 the future, see [Learn about Role Based Access Control (RBAC)](/support/how-to/overview-role-based-access-control-rbac).

--- a/content/how-to/account-management/account-management-faq/index.md
+++ b/content/how-to/account-management/account-management-faq/index.md
@@ -277,18 +277,18 @@ account might have access to.
 
 {{< accordion title="Where can I view the pop-up window that appeared when I initially enabled RBAC?" col="in" href="accordion30" hasImage="yes">}}
 
-<p>Following is the initial pop-up window that appears when you enable RBAC.</p>
+Following is the initial pop-up window that appears when you enable RBAC.<
 
 
 
 {{<image src="RBAC.png" alt="" title="">}}
 
 
-<p>For information about additional products that will be RBAC-enabled in
+For information about additional products that will be RBAC-enabled in
 the future, see [Learn about Role Based Access Control (RBAC)](/support/how-to/overview-role-based-access-control-rbac).
 
 For information about changing your admin credentials, see [Use Role-Based Access Control (RBAC)](/support/how-to/managing-role-based-access-control-rbac).
 
-For access to the Cloud Control Panel, log in at [https://login.rackspace.com/](https://login.rackspace.com/).</p>
+For access to the Cloud Control Panel, log in at [https://login.rackspace.com/](https://login.rackspace.com/).
 
 {{</ accordion >}}

--- a/content/how-to/account-management/account-management-faq/index.md
+++ b/content/how-to/account-management/account-management-faq/index.md
@@ -277,7 +277,7 @@ account might have access to.
 
 {{< accordion title="Where can I view the pop-up window that appeared when I initially enabled RBAC?" col="in" href="accordion30" hasImage="yes">}}
 
-Following is the initial pop-up window that appears when you enable RBAC.<
+Following is the initial pop-up window that appears when you enable RBAC.
 
 
 


### PR DESCRIPTION
the final FAQ has `<p>` tags in the text which might be causing the links to not form correctly.