### PR TITLE
Retire "Shut down a server article", it's redundant

### DIFF
--- a/content/how-to/retired-articles/shut-down-a-server/index.md
+++ b/content/how-to/retired-articles/shut-down-a-server/index.md
@@ -7,8 +7,7 @@ created_date: '2018-08-28'
 created_by: Rackspace Support
 last_modified_date: '2018-10-25'
 last_modified_by: Cat Lookabaugh
-product: Cloud Servers
-product_url: cloud-servers
+
 ---
 
 A common use case for shutting down a server is to determine whether the


### PR DESCRIPTION
Hi @stephamon Could you review this PR? This PR is only to retire this article. I've already taken care of the redirects.

Related to: 

https://github.com/rackerlabs/support-how-to/pull/803
Four server shutdown articles are very similar. We might need to merge or retire some or update one or more.
Per Shaun Crumpler who relayed a message from Russell Demetree.