### PR TITLE
Retire "Shut down a server from the Cloud portal" article, it's redundant.

### DIFF
--- a/content/how-to/retired-articles/shut-down-a-server-from-the-cloud-portal/index.md
+++ b/content/how-to/retired-articles/shut-down-a-server-from-the-cloud-portal/index.md
@@ -7,8 +7,7 @@ created_date: '2020-10-11'
 created_by: David Cano
 last_modified_date: '2020-10-13'
 last_modified_by: Rose Morales
-product: Cloud Servers
-product_url: cloud-servers
+
 ---
 
 This article describes how to shut down a Rackspace Cloud Server.


### PR DESCRIPTION
Hi @stephamon Could you review this PR? This PR is only to retire this article. I've already taken care of the redirects.

Related to:

#803
Four server shutdown articles are very similar. We might need to merge or retire some or update one or more.
Per Shaun Crumpler who relayed a message from Russell Demetree.