### PR TITLE
add link to SSL lb article

### DIFF
--- a/content/how-to/cloud-servers/install-an-ssl-certificate/index.md
+++ b/content/how-to/cloud-servers/install-an-ssl-certificate/index.md
@@ -5,7 +5,7 @@ title: Install an SSL certificate
 type: article
 created_date: '2018-10-23'
 created_by: Cat Lookabaugh
-last_modified_date: '2019-12-20'
+last_modified_date: '2021-04-28'
 last_modified_by: Stephanie Fillmon
 product: Cloud Servers
 product_url: cloud-servers
@@ -14,8 +14,12 @@ product_url: cloud-servers
 After you [generate a certificate signing request (CSR)](/support/how-to/generate-a-csr)
 and [purchase or renew a Secure Socket Layer (SSL) certificate](/support/how-to/purchase-or-renew-an-ssl-certificate/),
 you'll need to install it. This article shows you how to install an SSL
-certificate on various servers and operating systems. The following sections
-provide instructions for the installation process:
+certificate on various servers and operating systems.
+
+If you want to install an SSL certificate on a load balancer, see
+[Configure SSL certificates on Cloud Load Balancers](/support/how-to/configure-SSL-certificates-on-cloud-load-balancers).
+
+The following sections provide instructions for the installation process:
 
 - [Prerequisites](#prerequisites)
 


### PR DESCRIPTION
This change adds a link to configuring an SSL certificate on a load balancer to the main article about installing SSL certificates.