### PR TITLE
Retire Install and configure RXT Monitoring agent per Steph

### DIFF
--- a/content/how-to/retired-articles/RETIRING-CONTENT/install-and-configure-the-rackspace-monitoring-agent/index.md
+++ b/content/how-to/retired-articles/RETIRING-CONTENT/install-and-configure-the-rackspace-monitoring-agent/index.md
@@ -7,8 +7,7 @@ created_date: '2012-11-13'
 created_by: Susan Million
 last_modified_date: '2020-11-25'
 last_modified_by: Rose Morales
-product: Rackspace Monitoring
-product_url: rackspace-monitoring
+
 ---
 
 This article describes different methods for installing and configuring the

--- a/static/_redirects
+++ b/static/_redirects
@@ -51,6 +51,7 @@ support/how-to/rackspace-email-password-recovery-faq/  /support/how-to/manage-pa
 
 # Retired Articles
 
+/support/how-to/install-and-configure-the-rackspace-monitoring-agent/ /how-to/article-retired/ 404
 /support/how-to/access-a-private-rds-instance-with-putty/ /how-to/article-retired/ 404
 /support/how-to/using-python-novaclient-to-manage-scheduled-images/  /how-to/article-retired/ 404
 /support/how-to/rpc-vmware-all-articles /how-to/article-retired/ 404


### PR DESCRIPTION
First part, moved folder to retired articles section and deleted `product:`and `product url:`. 
Second part, redirected article to retired notification page.