### PR TITLE
Update Article - Red Hat and CentOS subscription

### DIFF
--- a/content/how-to/dedicated-hosting/rhel-and-centos-subscription-options-in-linux-infrastructures/index.md
+++ b/content/how-to/dedicated-hosting/rhel-and-centos-subscription-options-in-linux-infrastructures/index.md
@@ -1,12 +1,12 @@
 ---
 permalink: rhel-and-centos-subscription-options-in-linux-infrastructures
-audit_date: '2016-11-09'
+audit_date: '2022-31-01'
 title: Red Hat and CentOS subscription options in Linux infrastructures
 type: article
-created_date: '2016-11-02'
-created_by: Stephanie Fillmon
-last_modified_date: '2016-11-09'
-last_modified_by: Stephanie Fillmon
+created_date: '2022-31-01'
+created_by: Rackspace Support
+last_modified_date: '2022-31-01'
+last_modified_by: Miguel Salgado
 product: Dedicated Hosting
 product_url: dedicated-hosting
 ---
@@ -19,8 +19,4 @@ A server subscribed to the base channel is created with the most recent version 
 
 #### Locked point release
 
-A server subscribed to a locked point release channel is created with a specific minor version of that Red Hat Enterprise Linux or CentOS release (for example, 5.6) and is never updated beyond that version. Locked point releases should be used with caution, and only when you have specific software requirements.
-
-#### Rolling point release
-
-*(Red Hat only)* A rolling point release is typically used only when a server is subscribed to a Rackspace storage platform (for example, shared SAN) that requires OS certification for compatibility reasons. When subscribed to rolling point release, a server is created with the most recent minor release of Red Hat that is certified for that storage platform. When newer minor versions receive certification, Rackspace engineers open a ticket notifying you that your device will be moved to the new channel automatically on a future date unless you opt out. The move is for subscription purposes only; you are still required to update the server according to your own patching schedule.
+A server subscribed to a locked point release channel is created with a specific minor version of that Red Hat Enterprise Linux release (for example, 8.4)  and is never updated beyond that version. Locked point releases should be used with caution, and only when you have specific software requirements.


### PR DESCRIPTION
I have removed the Rolling point release paragraph and also corrected the locked point release information to reflect RHEL newest versions.